### PR TITLE
Updated task descriptors according to what was published on Zenodo

### DIFF
--- a/cbrain_task_descriptors/freesurfer-exec-centos7-freesurferbuild-centos4.json
+++ b/cbrain_task_descriptors/freesurfer-exec-centos7-freesurferbuild-centos4.json
@@ -1,6 +1,8 @@
 {
     "tool-version": "3.19.0-centos7", 
     "name": "FreeSurferPipelineBatch-CentOS7", 
+    "author": "Washington University", 
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/freesurfer-exec-centos7-freesurferbuild-centos4.json",
     "command-line": "freesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]", 
     "inputs": [
         {
@@ -47,5 +49,11 @@
     "suggested-resources": {
         "walltime-estimate": 25200
     }, 
-    "description": "FreeSurferPipelineBatch HCP pipeline"
+    "description": "FreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
 }

--- a/cbrain_task_descriptors/postfreesurfer-exec-centos7.json
+++ b/cbrain_task_descriptors/postfreesurfer-exec-centos7.json
@@ -1,6 +1,8 @@
 {
     "tool-version": "3.19.0-centos7", 
-    "name": "PostFreeSurferPipelineBatch-CentOS7", 
+    "name": "PostFreeSurferPipelineBatch-CentOS7",
+    "author": "Washington University",
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/postfreesurfer-exec-centos7.json", 
     "command-line": "postfreesurfer-command-line-script.sh [SUBJECT_FOLDER] [NAME] [LICENSE]", 
     "inputs": [
         {
@@ -47,5 +49,11 @@
     "suggested-resources": {
         "walltime-estimate": 25200
     }, 
-    "description": "PostFreeSurferPipelineBatch HCP pipeline"
+    "description": "PostFreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
 }

--- a/cbrain_task_descriptors/prefreesurfer-exec-centos7-fslbuild-centos5.json
+++ b/cbrain_task_descriptors/prefreesurfer-exec-centos7-fslbuild-centos5.json
@@ -1,6 +1,8 @@
 {
     "tool-version": "3.19.0-centos7", 
     "name": "PreFreeSurferPipelineBatch", 
+    "author": "Washington University", 
+    "descriptor-url": "https://github.com/big-data-lab-team/cbrain-plugins-hcp/blob/master/cbrain_task_descriptors/prefreesurfer-exec-centos7-fslbuild-centos5.json",
     "command-line": "command-line-script.sh [SUBJECT_FOLDER] [NAME]", 
     "inputs": [
         {
@@ -38,5 +40,11 @@
     "suggested-resources": {
         "walltime-estimate": 25200
     }, 
-    "description": "PreFreeSurferPipelineBatch HCP pipeline"
+    "description": "PreFreeSurferPipelineBatch HCP pipeline",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }
 }


### PR DESCRIPTION
Published the following descriptors to Zenodo as per boutiques/boutiques#174:
* https://zenodo.org/record/1450997
* https://zenodo.org/record/1450993
* https://zenodo.org/record/1450995

Added to each descriptor:
* Author (used the ones from https://brainhack101.github.io/neurolinks/)
* Tags
* Descriptor URL